### PR TITLE
Update pack versions and add emerald gear recipes

### DIFF
--- a/datapack/data/mcemeraldgear/recipes/emerald_axe.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_axe.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "EE",
+    "ES",
+    " S"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" },
+    "S": { "item": "minecraft:stick" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_axe" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_boots.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_boots.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "E E",
+    "E E"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_boots" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_chestplate.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_chestplate.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "E E",
+    "EEE",
+    "EEE"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_chestplate" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_helmet.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_helmet.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "EEE",
+    "E E"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_helmet" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_hoe.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_hoe.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "EE",
+    " S",
+    " S"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" },
+    "S": { "item": "minecraft:stick" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_hoe" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_leggings.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_leggings.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "EEE",
+    "E E",
+    "E E"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_leggings" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_pickaxe.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_pickaxe.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "EEE",
+    " S ",
+    " S "
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" },
+    "S": { "item": "minecraft:stick" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_pickaxe" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_shovel.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_shovel.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "E",
+    "S",
+    "S"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" },
+    "S": { "item": "minecraft:stick" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_shovel" }
+}
+

--- a/datapack/data/mcemeraldgear/recipes/emerald_sword.json
+++ b/datapack/data/mcemeraldgear/recipes/emerald_sword.json
@@ -1,0 +1,14 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "E",
+    "E",
+    "S"
+  ],
+  "key": {
+    "E": { "item": "minecraft:emerald" },
+    "S": { "item": "minecraft:stick" }
+  },
+  "result": { "id": "mcemeraldgear:emerald_sword" }
+}
+

--- a/datapack/pack.mcmeta
+++ b/datapack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 48,
+    "pack_format": 81,
     "description": "Emerald gear data pack"
   }
 }

--- a/resourcepack/pack.mcmeta
+++ b/resourcepack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 34,
+    "pack_format": 64,
     "description": "Emerald gear resource pack"
   }
 }


### PR DESCRIPTION
## Summary
- bump resource pack format to 64 and data pack format to 81
- add crafting recipes for all emerald gear items

## Testing
- `python -m json.tool resourcepack/pack.mcmeta`
- `python -m json.tool datapack/pack.mcmeta`
- `for f in datapack/data/mcemeraldgear/recipes/*.json; do python -m json.tool "$f" >/dev/null && echo "checked $f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68b3e6624c20832ea9669b894eb4d32c